### PR TITLE
Fix typos in scripts

### DIFF
--- a/functions/generate-passwords
+++ b/functions/generate-passwords
@@ -2,14 +2,14 @@
 
 generate-passwords() {
   if [ "$#" -ne 1 ]; then
-    echo "Usage: generate-password <amount of characters>"
+    echo "Usage: generate-passwords <amount of characters>"
     echo "Assuming 64 characters:\n"
-    pass_lenght=64
+    pass_length=64
   else
-    pass_lenght=${0}
+    pass_length=$1
   fi
 
   for i in {1..5};
-    do (tr -cd '[:alnum:]' < /dev/urandom | fold -w${pass_lenght}| head -n 1);
+    do (tr -cd '[:alnum:]' < /dev/urandom | fold -w${pass_length}| head -n 1);
   done
 }

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -60,7 +60,7 @@ make_zsh_default_shell () {
 		# Check zsh is installed, if not exit with warning
 		if ! which zsh &> /dev/null
 		then
-			fail "Zsh is needed. Please install it via your prefered package manager."
+                        fail "Zsh is needed. Please install it via your preferred package manager."
 		fi
 
 		# If zsh is not listed as a shell, list it


### PR DESCRIPTION
## Summary
- correct `prefered` to `preferred`
- fix variable typo `pass_lenght`

## Testing
- `pytest -q` *(fails: is_interactive_shell contains underscore(s) instead of hyphen(s); brewup is missing help parameter)*

------
https://chatgpt.com/codex/tasks/task_e_6842b9fff6fc8322a515475b26cda153